### PR TITLE
bugfix: add recovery from point, make retry logic configurable

### DIFF
--- a/es-core/src/main/kotlin/tech/figure/eventstream/stream/flows/MultiplexBlockDataFlow.kt
+++ b/es-core/src/main/kotlin/tech/figure/eventstream/stream/flows/MultiplexBlockDataFlow.kt
@@ -25,7 +25,8 @@ fun blockDataFlow(
     to: Long? = null,
     historicalFlow: (Long, Long) -> Flow<BlockData> = { f, t -> historicalBlockDataFlow(netAdapter, f, t) },
     liveFlow: () -> Flow<BlockData> = { pollingBlockDataFlow(netAdapter) },
-): Flow<BlockData> = combinedFlow(currentHeightFn(netAdapter), from, to, blockDataHeightFn, historicalFlow, liveFlow)
+    shouldRetry: suspend (Throwable, Long) -> Boolean = shouldRetryFn(),
+): Flow<BlockData> = combinedFlow(currentHeightFn(netAdapter), from, to, blockDataHeightFn, historicalFlow, liveFlow, shouldRetry)
 
 /**
  * Create a [Flow] of [BlockData] from height to height. Uses websockets under the hood for the live stream.

--- a/es-core/src/main/kotlin/tech/figure/eventstream/stream/flows/MultiplexBlockHeaderFlow.kt
+++ b/es-core/src/main/kotlin/tech/figure/eventstream/stream/flows/MultiplexBlockHeaderFlow.kt
@@ -26,7 +26,8 @@ fun blockHeaderFlow(
     to: Long? = null,
     historicalFlow: (Long, Long) -> Flow<BlockHeader> = { f, t -> historicalBlockHeaderFlow(netAdapter, f, t) },
     liveFlow: () -> Flow<BlockHeader> = { pollingBlockHeaderFlow(netAdapter) },
-): Flow<BlockHeader> = combinedFlow(currentHeightFn(netAdapter), from, to, blockHeaderHeightFn, historicalFlow, liveFlow)
+    shouldRetry: suspend (Throwable, Long) -> Boolean = shouldRetryFn(),
+): Flow<BlockHeader> = combinedFlow(currentHeightFn(netAdapter), from, to, blockHeaderHeightFn, historicalFlow, liveFlow, shouldRetry)
 
 /**
  * Create a [Flow] of [BlockHeader] from height to height. Uses web sockets under the hood for live data.


### PR DESCRIPTION
Looking for feedback on bugfix/tweaks to support two behaviors we've observed when using `combinedFlow`:

1. When the `Flow` is restarted it uses the original `from` block height when the flow was first initiated. This will re-process past blocks and for long-running historical flows this can cause infinite loop behavior in which the stream never catches up to the live height.
2. Default Exponential backoff logic is tied to the `retryWhen` `attempt` parameter, which is always incrementing and never resets. This means errors that occur within a few seconds or within a few days of each other will still backoff at the same rate. This is not desirable for a long-lived process where occasional errors will occur.

This PR attempts to fix problem 1 by using a pointer to the most recently processed block, and by making error logic configurable.