### PR TITLE
feature: Expose okhttp client builder for net adapter construction

### DIFF
--- a/es-core/src/main/kotlin/tech/figure/eventstream/net/OkHttpAdapter.kt
+++ b/es-core/src/main/kotlin/tech/figure/eventstream/net/OkHttpAdapter.kt
@@ -1,31 +1,32 @@
 package tech.figure.eventstream.net
 
 import com.tinder.scarlet.websocket.okhttp.newWebSocketFactory
-import tech.figure.eventstream.stream.clients.TendermintBlockFetcher
-import tech.figure.eventstream.stream.clients.TendermintServiceOpenApiClient
 import mu.KotlinLogging
 import okhttp3.OkHttpClient
 import tech.figure.eventstream.awaitShutdown
+import tech.figure.eventstream.stream.clients.TendermintBlockFetcher
+import tech.figure.eventstream.stream.clients.TendermintServiceOpenApiClient
 import java.net.URI
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.ExperimentalTime
 import kotlin.time.toJavaDuration
 
 private val SSL_SCHEMES = setOf("grpcs", "https", "tcp+tls", "wss")
 private val NON_SSL_SCHEMES = setOf("grpc", "http", "tcp", "ws")
 
 /**
- * Create a default [OkHttpClient] to use within the event stream.
+ * Return [OkHttpClient.Builder] extension lambda that constructs the default [OkHttpClient] to use within the event stream.
  */
-@OptIn(ExperimentalTime::class)
-fun defaultOkHttpClient(pingInterval: Duration = 10.seconds, readInterval: Duration = 60.seconds) =
-    OkHttpClient.Builder()
-        .pingInterval(pingInterval.toJavaDuration())
-        .readTimeout(readInterval.toJavaDuration())
-        .connectTimeout(90.seconds.toJavaDuration())
-        .callTimeout(30.seconds.toJavaDuration())
-        .build()
+fun defaultOkHttpClientBuilderFn(
+    pingInterval: Duration = 10.seconds,
+    readInterval: Duration = 60.seconds
+): OkHttpClient.Builder.() -> OkHttpClient.Builder =
+    {
+        pingInterval(pingInterval.toJavaDuration())
+        readTimeout(readInterval.toJavaDuration())
+        connectTimeout(90.seconds.toJavaDuration())
+        callTimeout(30.seconds.toJavaDuration())
+    }
 
 /**
  * Create the [OkHttpClient] flavor of the required [NetAdapter] fields.
@@ -34,16 +35,37 @@ fun defaultOkHttpClient(pingInterval: Duration = 10.seconds, readInterval: Durat
  * @param okHttpClient The [OkHttpClient] instance to use for http calls.
  * @return The [NetAdapter] instance.
  */
-fun okHttpNetAdapter(node: String, okHttpClient: OkHttpClient = defaultOkHttpClient()): NetAdapter {
+@Deprecated("Deprecated in favor of passing OkHttpClient.Builder lambda instead of OkHttpClient so client configuration cab be applied to both ws and rpc interfaces")
+fun okHttpNetAdapter(node: String, okHttpClient: OkHttpClient): NetAdapter {
     val log = KotlinLogging.logger {}
     val (rpcUri, wsUri) = nodeToNetAdapterURIs(node)
 
+    log.warn { "Using deprecated okHttpNetAdapter constructor, okHttpClient settings will only be applied to ws endpoints" }
     log.info { "initializing ws endpoint $wsUri" }
     log.info { "initializing rpc endpoint $rpcUri" }
 
     return netAdapter(
         okHttpClient.newWebSocketFactory("$wsUri/websocket")::create,
         TendermintBlockFetcher(TendermintServiceOpenApiClient(rpcUri)),
+        okHttpClient::awaitShutdown
+    )
+}
+
+fun okHttpNetAdapter(
+    node: String,
+    clientBuilderFn: OkHttpClient.Builder.() -> OkHttpClient.Builder = defaultOkHttpClientBuilderFn()
+): NetAdapter {
+    val log = KotlinLogging.logger {}
+    val (rpcUri, wsUri) = nodeToNetAdapterURIs(node)
+
+    log.info { "initializing ws endpoint $wsUri" }
+    log.info { "initializing rpc endpoint $rpcUri" }
+
+    val okHttpClient = clientBuilderFn(OkHttpClient.Builder()).build()
+
+    return netAdapter(
+        okHttpClient.newWebSocketFactory("$wsUri/websocket")::create,
+        TendermintBlockFetcher(TendermintServiceOpenApiClient(rpcUri, clientBuilderFn)),
         okHttpClient::awaitShutdown
     )
 }

--- a/es-core/src/main/kotlin/tech/figure/eventstream/stream/clients/TendermintServiceOpenApiClient.kt
+++ b/es-core/src/main/kotlin/tech/figure/eventstream/stream/clients/TendermintServiceOpenApiClient.kt
@@ -1,7 +1,9 @@
 package tech.figure.eventstream.stream.clients
 
+import okhttp3.OkHttpClient
 import tech.figure.eventstream.stream.apis.ABCIApi
 import tech.figure.eventstream.stream.apis.InfoApi
+import tech.figure.eventstream.stream.infrastructure.ApiClient
 import tech.figure.eventstream.stream.models.ABCIInfoResponse
 import tech.figure.eventstream.stream.models.BlockResponse
 import tech.figure.eventstream.stream.models.BlockResultsResponse
@@ -13,8 +15,16 @@ import tech.figure.eventstream.stream.models.BlockchainResponse
  * All requests and responses are HTTP+JSON.
  *
  * @param rpcUrlBase The base URL of the Tendermint RPC API to use when making requests.
+ * @param configureBuilderFn Builder lambda to configure the underlying [OkHttpClient]
  */
-class TendermintServiceOpenApiClient(rpcUrlBase: String) : TendermintServiceClient {
+class TendermintServiceOpenApiClient(
+    rpcUrlBase: String,
+    configureBuilderFn: OkHttpClient.Builder.() -> OkHttpClient.Builder = { this }
+) : TendermintServiceClient {
+    init {
+        ApiClient.builder.apply { configureBuilderFn() }
+    }
+
     private val abciApi = ABCIApi(rpcUrlBase)
     private val infoApi = InfoApi(rpcUrlBase)
 


### PR DESCRIPTION
Currently the `okHttpNetAdapter`'s `OkHttpClient` is only being used for the ws/live flows. This PR applies the given `OkHttpClient` configuration to both the live and historical flows by changing to accept a builder lambda and then passing that function down to the generated `ApiClient` used by the Tendermint RPC clients.

Context: We are having connectivity issues running event-stream lib against the private provenance instance setup for USDF applications and are looking for ways to fine tune the http calls being made and reduce instability.