### PR TITLE
Bugfix: Fix fee parsing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,26 @@ tasks.test {
     finalizedBy("jacocoTestReport")
 }
 
+val javaVersion = JavaVersion.VERSION_11
+subprojects {
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+        kotlinOptions {
+            freeCompilerArgs = freeCompilerArgs + listOf("-Xjsr305=strict", "-opt-in=kotlin.RequiresOptIn", "-opt-in=kotlin.time.ExperimentalTime")
+            jvmTarget = "11"
+        }
+    }
+    tasks.withType<JavaCompile> {
+        sourceCompatibility = JavaVersion.VERSION_11.toString()
+        targetCompatibility = JavaVersion.VERSION_11.toString()
+    }
+
+    // Set the java version
+    configure<JavaPluginExtension> {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+}
+
 dependencies {
     implementation(projects.esCore)
     implementation(projects.esKafka)

--- a/buildSrc/src/main/kotlin/core-config.gradle.kts
+++ b/buildSrc/src/main/kotlin/core-config.gradle.kts
@@ -57,27 +57,6 @@ dependencies {
     implementation("com.sksamuel.hoplite", "hoplite-yaml", Versions.Hoplite)
 }
 
-// Compilation:
-tasks.withType<KotlinCompile> {
-    kotlinOptions {
-        freeCompilerArgs = listOf("-Xjsr305=strict", "-Xopt-in=kotlin.RequiresOptIn", "-Xopt-in=kotlin.time.ExperimentalTime")
-        jvmTarget = "11"
-    }
-}
-
-tasks.withType<JavaCompile> {
-    sourceCompatibility = JavaVersion.VERSION_11.toString()
-    targetCompatibility = JavaVersion.VERSION_11.toString()
-}
-
-// Set the java version
-configure<JavaPluginExtension> {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-}
-
-
-
 // Testing:
 tasks.test {
     useJUnitPlatform()

--- a/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/Extensions.kt
+++ b/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/Extensions.kt
@@ -95,12 +95,14 @@ fun BlockResultsResponseResult.txErroredEvents(blockDateTime: OffsetDateTime?, t
     run {
         txsResults?.mapIndexed { index: Int, tx: BlockResultsResponseResultTxsResults ->
             if (tx.code?.toInt() != 0) {
-                tx.toBlockError(
-                    blockHeight = height,
-                    blockDateTime = blockDateTime,
-                    txHash = txHash(index)?.txHash,
-                    fee = txHash(index)?.fee,
-                )
+                txHash(index).let { txData ->
+                    tx.toBlockError(
+                        blockHeight = height,
+                        blockDateTime = blockDateTime,
+                        txHash = txData?.txHash,
+                        fee = txData?.fee,
+                    )
+                }
             } else {
                 null
             }

--- a/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/Extensions.kt
+++ b/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/Extensions.kt
@@ -3,6 +3,7 @@ package tech.figure.eventstream.stream.models
 import com.google.common.io.BaseEncoding
 import cosmos.base.v1beta1.CoinOuterClass.Coin
 import cosmos.tx.v1beta1.TxOuterClass
+import java.math.BigInteger
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
 import java.time.OffsetDateTime
@@ -116,7 +117,8 @@ fun BlockResultsResponseResultTxsResults.toBlockError(blockHeight: Long, blockDa
         code = this.code?.toLong() ?: 0L,
         info = this.log ?: "",
         txHash = txHash ?: "",
-        fee = fee
+        fee = fee?.amount ?: BigInteger.ZERO,
+        denom = fee?.denom ?: "",
     )
 
 fun BlockResultsResponseResultEvents.toBlockEvent(blockHeight: Long, blockDateTime: OffsetDateTime?): BlockEvent =
@@ -140,7 +142,8 @@ fun BlockResultsResponseResultEvents.toTxEvent(
         txHash = txHash ?: "",
         eventType = this.type ?: "",
         attributes = this.attributes ?: emptyList(),
-        fee = fee,
+        fee = fee?.amount,
+        denom = fee?.denom,
         note = note
     )
 

--- a/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/InnerCoin.kt
+++ b/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/InnerCoin.kt
@@ -1,0 +1,7 @@
+package tech.figure.eventstream.stream.models
+
+import cosmos.base.v1beta1.CoinOuterClass.Coin
+
+data class InnerCoin(val amount: String, val denom: String) {
+    constructor(coin: Coin) : this(amount = coin.amount, denom = coin.denom)
+}

--- a/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/InnerCoin.kt
+++ b/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/InnerCoin.kt
@@ -1,7 +1,8 @@
 package tech.figure.eventstream.stream.models
 
 import cosmos.base.v1beta1.CoinOuterClass.Coin
+import java.math.BigInteger
 
-data class InnerCoin(val amount: String, val denom: String) {
-    constructor(coin: Coin) : this(amount = coin.amount, denom = coin.denom)
+data class InnerCoin(val amount: BigInteger, val denom: String) {
+    constructor(coin: Coin) : this(amount = coin.amount.toBigIntegerOrNull() ?: BigInteger.ZERO, denom = coin.denom)
 }

--- a/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/TxData.kt
+++ b/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/TxData.kt
@@ -1,7 +1,9 @@
 package tech.figure.eventstream.stream.models
 
+import cosmos.base.v1beta1.CoinOuterClass.Coin
+
 data class TxData(
     val txHash: String?,
-    val fee: Pair<Long?, String?>?,
+    val fee: Coin?,
     val note: String?
 )

--- a/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/TxData.kt
+++ b/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/TxData.kt
@@ -1,9 +1,7 @@
 package tech.figure.eventstream.stream.models
 
-import cosmos.base.v1beta1.CoinOuterClass.Coin
-
 data class TxData(
     val txHash: String?,
-    val fee: Coin?,
+    val fee: InnerCoin?,
     val note: String?
 )

--- a/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/TxError.kt
+++ b/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/TxError.kt
@@ -14,5 +14,5 @@ data class TxError(
     val code: Long,
     val info: String,
     val txHash: String,
-    val fee: Coin?,
+    val fee: InnerCoin?,
 )

--- a/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/TxError.kt
+++ b/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/TxError.kt
@@ -1,6 +1,7 @@
 package tech.figure.eventstream.stream.models
 
 import com.squareup.moshi.JsonClass
+import cosmos.base.v1beta1.CoinOuterClass.Coin
 import java.time.OffsetDateTime
 
 /**
@@ -13,6 +14,5 @@ data class TxError(
     val code: Long,
     val info: String,
     val txHash: String,
-    val fee: Long,
-    val denom: String
+    val fee: Coin?,
 )

--- a/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/TxError.kt
+++ b/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/TxError.kt
@@ -1,6 +1,7 @@
 package tech.figure.eventstream.stream.models
 
 import com.squareup.moshi.JsonClass
+import java.math.BigInteger
 import java.time.OffsetDateTime
 
 /**
@@ -13,5 +14,6 @@ data class TxError(
     val code: Long,
     val info: String,
     val txHash: String,
-    val fee: InnerCoin?,
+    val fee: BigInteger,
+    val denom: String,
 )

--- a/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/TxError.kt
+++ b/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/TxError.kt
@@ -1,7 +1,6 @@
 package tech.figure.eventstream.stream.models
 
 import com.squareup.moshi.JsonClass
-import cosmos.base.v1beta1.CoinOuterClass.Coin
 import java.time.OffsetDateTime
 
 /**

--- a/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/TxEvent.kt
+++ b/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/TxEvent.kt
@@ -1,6 +1,7 @@
 package tech.figure.eventstream.stream.models
 
 import com.squareup.moshi.JsonClass
+import java.math.BigInteger
 import java.time.OffsetDateTime
 
 /**
@@ -14,6 +15,7 @@ data class TxEvent(
     val txHash: String,
     override val eventType: String,
     override val attributes: List<Event>,
-    val fee: InnerCoin?,
+    val fee: BigInteger?,
+    val denom: String?,
     val note: String?
 ) : EncodedBlockchainEvent

--- a/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/TxEvent.kt
+++ b/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/TxEvent.kt
@@ -1,6 +1,7 @@
 package tech.figure.eventstream.stream.models
 
 import com.squareup.moshi.JsonClass
+import cosmos.base.v1beta1.CoinOuterClass.Coin
 import java.time.OffsetDateTime
 
 /**
@@ -14,7 +15,6 @@ data class TxEvent(
     val txHash: String,
     override val eventType: String,
     override val attributes: List<Event>,
-    val fee: Long?,
-    val denom: String?,
+    val fee: Coin?,
     val note: String?
 ) : EncodedBlockchainEvent

--- a/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/TxEvent.kt
+++ b/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/TxEvent.kt
@@ -15,6 +15,6 @@ data class TxEvent(
     val txHash: String,
     override val eventType: String,
     override val attributes: List<Event>,
-    val fee: Coin?,
+    val fee: InnerCoin?,
     val note: String?
 ) : EncodedBlockchainEvent

--- a/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/TxEvent.kt
+++ b/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/TxEvent.kt
@@ -1,7 +1,6 @@
 package tech.figure.eventstream.stream.models
 
 import com.squareup.moshi.JsonClass
-import cosmos.base.v1beta1.CoinOuterClass.Coin
 import java.time.OffsetDateTime
 
 /**

--- a/es-cli/build.gradle.kts
+++ b/es-cli/build.gradle.kts
@@ -5,10 +5,6 @@ plugins {
     id("core-config")
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation(projects.esApi)
     implementation(projects.esApiModel)
@@ -26,11 +22,4 @@ dependencies {
 application {
     applicationName = "event-stream"
     mainClass.set("MainKt")
-}
-
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    kotlinOptions {
-        freeCompilerArgs = listOf("-Xjsr305=strict", "-Xopt-in=kotlin.RequiresOptIn", "-Xopt-in=kotlin.time.ExperimentalTime")
-        jvmTarget = "11"
-    }
 }

--- a/es-core/build.gradle.kts
+++ b/es-core/build.gradle.kts
@@ -32,10 +32,3 @@ dependencies {
 kapt {
     correctErrorTypes = true
 }
-
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    kotlinOptions {
-        freeCompilerArgs = listOf("-Xjsr305=strict", "-Xopt-in=kotlin.RequiresOptIn", "-Xopt-in=kotlin.time.ExperimentalTime")
-        jvmTarget = "11"
-    }
-}


### PR DESCRIPTION
# Description
I decided it would be cool to create a msg tx with 18 billion hash as the proposed fee.  ES parses these values as longs, which this number exceeds and causes overflow.  Hooray Friday.