### PR TITLE
Surface more block related utility methods

### DIFF
--- a/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/EncodedBlockchainEvent.kt
+++ b/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/EncodedBlockchainEvent.kt
@@ -1,7 +1,5 @@
 package tech.figure.eventstream.stream.models
 
-import java.util.Base64
-
 /**
  * Common interface for various blockchain event types that are encoded as an event type followed by a series of
  * event key/value attributes conforming to the format defined in `provenance/attribute/v1/attribute.proto`.
@@ -107,6 +105,3 @@ interface EncodedBlockchainEvent {
  *     "scope_addr"   to "InNjb3BlMXF6bTN4YWd4NzZ1eXZnNGs3eXZ4Yzd1aG51Z3F6ZW1tbTci"
  *   }
  */
-fun List<Event>.toDecodedMap(): Map<String, String?> = associate { e ->
-    Base64.getDecoder().decode(e.key).decodeToString() to e.value
-}

--- a/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/Extensions.kt
+++ b/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/Extensions.kt
@@ -8,6 +8,7 @@ import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
+import java.util.Base64
 
 /**
  * Compute a hex-encoded (printable) version of a SHA-256 encoded byte array.
@@ -33,8 +34,6 @@ fun sha256(input: ByteArray?): ByteArray =
  */
 fun String.hash(): String = sha256(BaseEncoding.base64().decode(this)).toHexString()
 
-// === Date/time methods ===============================================================================================
-
 fun Block.txData(index: Int): TxData? {
     val tx = this.data?.txs?.get(index) ?: return null
 
@@ -50,10 +49,25 @@ fun Block.txData(index: Int): TxData? {
     )
 }
 
+/**
+ * Return the hashes of the transactions contained in this block.
+ *
+ * @return A list of transaction hashes.
+ */
 fun Block.txHashes(): List<String> = this.data?.txs?.map { it.hash() } ?: emptyList()
 
-fun Block.dateTime() = this.header?.dateTime()
+/**
+ * Return the creation time of the block.
+ *
+ * @return The time the block was created.  If the date is missing or invalid, null will be returned
+ */
+fun Block.dateTime(): OffsetDateTime? = this.header?.dateTime()
 
+/**
+ * Return the creation time of the block header.
+ *
+ * @return The time the block was created.  If the date is missing or invalid, null will be returned
+ */
 fun BlockHeader.dateTime(): OffsetDateTime? =
     runCatching { OffsetDateTime.parse(this.time, DateTimeFormatter.ISO_DATE_TIME) }.getOrNull()
 
@@ -148,3 +162,29 @@ fun BlockResultsResponseResultEvents.toTxEvent(
     )
 
 fun Coin.toInnerCoin(): InnerCoin = InnerCoin(coin = this)
+
+/**
+ * Check if a [TxEvent] contains a specific attribute.
+ *
+ * @param key The name of the attribute to check for.
+ * @return boolean
+ */
+fun TxEvent.hasAttribute(key: String): Boolean = attributes.any { it.key == key }
+
+/**
+ * Convert an [Event] to an attribute, e.g. a String key/value pair, where the key and value are base64 decoded.
+ *
+ * @return A base64 decoded key/value value.
+ */
+fun Event.toAttribute(): Pair<String, String?> {
+    val decoder = Base64.getDecoder()
+    return String(decoder.decode(key)) to (value?.run { String(decoder.decode(this)) })
+}
+
+/**
+ * Base64 decodes the contents of [EncodedBlockchainEvent.attributes], collecting the key/value pairs into a [Map]
+ *
+ * @return A [Map] containing the base64 decoded key/value pairs.
+ */
+fun EncodedBlockchainEvent.toMap(): Map<String, String?> =
+    attributes.map { it.toAttribute() }.associate { it.first to it.second }.toMap()

--- a/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/Extensions.kt
+++ b/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/Extensions.kt
@@ -186,5 +186,6 @@ fun Event.toAttribute(): Pair<String, String?> {
  *
  * @return A [Map] containing the base64 decoded key/value pairs.
  */
-fun EncodedBlockchainEvent.toMap(): Map<String, String?> =
-    attributes.map { it.toAttribute() }.associate { it.first to it.second }.toMap()
+fun List<Event>.toDecodedMap(): Map<String, String?> = associate { e ->
+    Base64.getDecoder().decode(e.key).decodeToString() to e.value
+}

--- a/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/StreamBlock.kt
+++ b/es-api-model/src/main/kotlin/tech/figure/eventstream/stream/models/StreamBlock.kt
@@ -10,6 +10,8 @@ interface StreamBlock {
     val txErrors: List<TxError>
     val historical: Boolean
     val height: Long? get() = block.header?.height
+
+    fun isEmpty(): Boolean = block.data?.txs?.isEmpty() ?: true
 }
 
 /**

--- a/es-core/src/main/kotlin/tech/figure/eventstream/stream/clients/BlockFetcher.kt
+++ b/es-core/src/main/kotlin/tech/figure/eventstream/stream/clients/BlockFetcher.kt
@@ -9,9 +9,47 @@ import kotlinx.coroutines.flow.DEFAULT_CONCURRENCY
 import kotlinx.coroutines.flow.Flow
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
+import tech.figure.eventstream.stream.models.StreamBlock
+import tech.figure.eventstream.stream.models.StreamBlockImpl
+import tech.figure.eventstream.stream.models.TxEvent
+import tech.figure.eventstream.stream.models.blockEvents
+import tech.figure.eventstream.stream.models.dateTime
+import tech.figure.eventstream.stream.models.txData
+import tech.figure.eventstream.stream.models.txErroredEvents
+import tech.figure.eventstream.stream.models.txEvents
 
+/**
+ * A data class encapsulating a Provenance block, containing metadata about the block as well as the actual transaction
+ * data itself.
+ */
 data class BlockData(val block: Block, val blockResult: BlockResultsResponseResult) {
-    val height = block.header!!.height
+    /**
+     * The height of the block.
+     *
+     * @return The height of the block.
+     */
+    val height: Long = block.header!!.height
+
+    /**
+     * List all transaction events occurring in the block.
+     *
+     * @return A list of all events associated with transactions that are a part of this block.
+     */
+    fun txEvents(): List<TxEvent> = blockResult.txEvents(block.dateTime()) { index -> block.txData(index) }
+
+    /**
+     * Converts this block data container into an instance of [StreamBlock].
+     *
+     * @return A [StreamBlock] instance.
+     */
+    fun toStreamBlock(): StreamBlock {
+        val blockDatetime = block.header?.dateTime()
+        val blockEvents = blockResult.blockEvents(blockDatetime)
+        val blockTxResults = blockResult.txsResults
+        val txEvents = blockResult.txEvents(blockDatetime) { index: Int -> block.txData(index) }
+        val txErrors = blockResult.txErroredEvents(blockDatetime) { index: Int -> block.txData(index) }
+        return StreamBlockImpl(block = block, blockEvents = blockEvents, blockResult = blockTxResults, txEvents = txEvents, txErrors = txErrors)
+    }
 }
 
 open class BlockFetchException(m: String) : Exception(m)


### PR DESCRIPTION
In the course of work on https://github.com/FigureTechnologies/service-exchange and elsewhere, a few useful extension methods were written that I'd like to backport into the `event-stream` library, as others may find them useful.

To this end, I'd like to:

1) Expose more extension methods on block data:

* `TxEvent.hasAttribute(): Boolean`
* `Event.toAttribute(): Pair<String, String?>`
* `EncodedBlockchainEvent.toMap(): Map<String, String?>`

2) Additionally, expose the following on `StreamBlock`:

* `StreamBlock.isEmpty(): Boolean`
* `BlockData.txEvents(): List<TxEvent>`
* `BlockData.toStreamBlock(): StreamBlock`